### PR TITLE
Added Issue labeler work flow

### DIFF
--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -30,7 +30,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
-              "name": "hacktoberfest",
+              "name": "hacktoberfest-accepted",
               "color": "FF7518",
               "description": "Hacktoberfest participation"
             }'

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -1,0 +1,55 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  manage-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Create or Update Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "gssoc-extd",
+              "color": "0E8A16",
+              "description": "GSSOC extended contribution"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "hacktoberfest",
+              "color": "FF7518",
+              "description": "Hacktoberfest participation"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "level?",
+              "color": "5319E7",
+              "description": "Placeholder for difficulty level"
+            }'
+
+      - name: Add Labels to Issue
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            gssoc-extd
+            hacktoberfest
+            level?

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -20,7 +20,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
-              "name": "gssoc-extd",
+              "name": "gssoc-ext",
               "color": "55a0ea",
               "description": "GSSOC extended contribution"
             }'
@@ -30,9 +30,19 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
+              "name": "hacktoberfest",
+              "color": "ff7518",
+              "description": "Hacktoberfest participation"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
               "name": "hacktoberfest-accepted",
               "color": "263432",
-              "description": "Hacktoberfest participation"
+              "description": "Hacktoberfest contribution accepted"
             }'
 
           curl -X POST \
@@ -50,6 +60,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            gssoc-extd
+            gssoc-ext
             hacktoberfest
+            hacktoberfest-accepted
             level?

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -21,7 +21,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "gssoc-ext",
-              "color": "0E4075",
+              "color": "0e4075",
               "description": "GSSOC extended contribution"
             }'
 
@@ -41,7 +41,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "hacktoberfest-accepted",
-              "color": "95D2AA",
+              "color": "95d2aa",
               "description": "Hacktoberfest contribution accepted"
             }'
 
@@ -51,7 +51,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "level?",
-              "color": "5319E7",
+              "color": "5319e7",
               "description": "Placeholder for difficulty level"
             }'
 

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -21,7 +21,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "gssoc-ext",
-              "color": "55a0ea",
+              "color": "0E4075",
               "description": "GSSOC extended contribution"
             }'
 
@@ -31,7 +31,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "hacktoberfest",
-              "color": "ff7518",
+              "color": "006b75",
               "description": "Hacktoberfest participation"
             }'
 
@@ -41,7 +41,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "hacktoberfest-accepted",
-              "color": "263432",
+              "color": "95D2AA",
               "description": "Hacktoberfest contribution accepted"
             }'
 

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -21,7 +21,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "gssoc-extd",
-              "color": "0E8A16",
+              "color": "55a0ea",
               "description": "GSSOC extended contribution"
             }'
 
@@ -31,7 +31,7 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
               "name": "hacktoberfest-accepted",
-              "color": "FF7518",
+              "color": "263432",
               "description": "Hacktoberfest participation"
             }'
 


### PR DESCRIPTION
## Description:  
This PR adds a GitHub Action to automate labeling of issues on creation or edit.  
The labels added are `gssoc-extd` (green), `hacktoberfest` (orange), and `level?` (purple).  
`level?` serves as a placeholder until the project admin assigns the final level during PR review.  
The workflow uses the GitHub API to ensure labels are updated with correct colors and descriptions

Fix #156 

@rohitinu6
Pls add labels like level3,gssoc-extd,hacktoberfest-accepted.