### PR TITLE
Fix YAML multiline error in GitHub Action workflow

### DIFF
--- a/.github/workflows/pr-checker.yaml
+++ b/.github/workflows/pr-checker.yaml
@@ -42,8 +42,7 @@ if not re.search(r'Fixes #[0-9]+', pr_description):
     sys.exit(1)
 
 # Check if the PR title starts with FIX, FEAT, or DOC
-if not re.match(r'^(Fixes|Close|Closes|Closed|Fix|Fixed|Resolve|Resolves
-Resolved)', pr_title):
+if not re.match(r'^(Fixes|Close|Closes|Closed|Fix|Fixed|Resolve|Resolves|Resolved)', pr_title):
     print('The PR title should start with Fixes , Close, Closes, Closed , Fix , Fixed , Resolve , Resolves')
     sys.exit(1)
 
@@ -55,4 +54,3 @@ print('PR description and title are valid.')
 
       - name: Output result
         run: echo "All checks passed."
-        


### PR DESCRIPTION
### Description of the Issue
This PR addresses the issue where the GitHub Action workflow fails with the error:

```
Error: cannot read a block mapping entry; a multiline key may not be an implicit key
```
### Issue Reference
Fixes #228

The error occurs because the `re.match` regular expression in the Python code block is split across multiple lines, which YAML does not interpret correctly.

### Fix Summary
The issue was fixed by modifying the `re.match` pattern in the YAML file, combining it into a single line within the `run` command. This ensures YAML can correctly parse and execute the Python script within the GitHub Action.

### Changes Made
- Updated the `re.match` pattern in the `Check PR Description and Title` step to be on a single line.
- Verified that the YAML file now correctly processes the multiline Python command without errors.